### PR TITLE
删除jshint.js中多余的判断条件

### DIFF
--- a/lib/jshint.js
+++ b/lib/jshint.js
@@ -37,7 +37,7 @@ function readDir( dir, startDir, conf, result ) {
         }
 
         var fsStat = fs.statSync( filename );
-        if ( fsStat.isDirectory() && filename !== 'scaffold') {
+        if ( fsStat.isDirectory() ) {
             readDir( filename, startDir, conf, result );
         }
         else if ( 


### PR DESCRIPTION
手误导致.

ISSUE=IGNORE
TASK=IGNORE
LBID=IGNORE
